### PR TITLE
修复IOS11下隐藏了导航条后，scrollview的inset因为save inset引起页面顶部不对齐的问题。

### DIFF
--- a/IKit/ITable.m
+++ b/IKit/ITable.m
@@ -603,7 +603,15 @@
 - (void)layoutHeaderFooterView{
 	//log_debug(@"%s", __func__);
 	if(_headerView){
-		CGFloat y = _scrollView.contentOffset.y + _scrollView.contentInset.top;
+        CGFloat y = 0;
+        
+        //fix ios 11 adjustedContentInset by xusion
+        if (@available(iOS 11.0, *)) {
+            y = _scrollView.contentOffset.y + _scrollView.adjustedContentInset.top;
+        }else{
+            y = _scrollView.contentOffset.y + _scrollView.contentInset.top;
+        }
+        
 		if(y < 0){
 			y = 0;
 		}


### PR DESCRIPTION
修复IOS11下隐藏了导航条后，scrollview的inset因为save inset引起页面顶部不对齐的问题。如：隐藏导航条，显示状态栏情况下，scrollview的y应该是状态栏的高度而不是为零。