### PR TITLE
修复IOS11下隐藏了导航条后，scrollview的inset因为save inset引起页面顶部不对齐的问题

### DIFF
--- a/IKit/IPullRefresh.m
+++ b/IKit/IPullRefresh.m
@@ -34,6 +34,12 @@
 - (CGFloat)headerVisibleRate{
 	if(_headerView && _headerView.frame.size.height > 0){
 		CGFloat visibleHeight = - (_scrollView.contentInset.top + _scrollView.contentOffset.y);
+        
+        //fix IOS 11 adjustedContentInset by xusion
+        if (@available(iOS 11.0, *)) {
+            visibleHeight = - (_scrollView.adjustedContentInset.top + _scrollView.contentOffset.y);
+        }
+        
 		//log_trace(@"header: visibleHeight=%f height=%f", visibleHeight, _headerView.frame.size.height);
 		CGFloat rate = visibleHeight / _headerView.frame.size.height;
 		return rate;
@@ -44,11 +50,22 @@
 - (CGFloat)footerVisibleRate{
 	if(_footerView && _footerView.frame.size.height > 0){
 		CGFloat visibleHeight;
-		if(_scrollView.contentSize.height + _scrollView.contentInset.top > _scrollView.frame.size.height){
-			visibleHeight = _scrollView.contentOffset.y + _scrollView.frame.size.height - _scrollView.contentSize.height;
-		}else{
-			visibleHeight = _scrollView.contentOffset.y + _scrollView.contentInset.top;
-		}
+        
+        //fix IOS 11 adjustedContentInset by xusion
+        if (@available(iOS 11.0, *)) {
+            if(_scrollView.contentSize.height + _scrollView.adjustedContentInset.top > _scrollView.frame.size.height){
+                visibleHeight = _scrollView.contentOffset.y + _scrollView.frame.size.height - _scrollView.contentSize.height;
+            }else{
+                visibleHeight = _scrollView.contentOffset.y + _scrollView.adjustedContentInset.top;
+            }
+        }else{
+            if(_scrollView.contentSize.height + _scrollView.contentInset.top > _scrollView.frame.size.height){
+                visibleHeight = _scrollView.contentOffset.y + _scrollView.frame.size.height - _scrollView.contentSize.height;
+            }else{
+                visibleHeight = _scrollView.contentOffset.y + _scrollView.contentInset.top;
+            }
+        }
+		
 		//log_trace(@"footer: visibleHeight=%f height=%f", visibleHeight, _footerView.frame.size.height);
 		//log_trace(@"footer.frame: %@, content: %f, offset: %f", NSStringFromCGRect(_footerView.frame), _scrollView.contentSize.height, _scrollView.contentOffset.y);
 		CGFloat rate = visibleHeight / _footerView.frame.size.height;
@@ -180,11 +197,21 @@
 		}else{
 			tmp_inset.bottom = _footerView.frame.size.height * _footerVisibleRateToRefresh;
 			
-			if(_scrollView.contentSize.height + _scrollView.contentInset.top + _footerView.frame.size.height > _scrollView.frame.size.height){
-				offset.y = _footerView.frame.origin.y + _footerView.frame.size.height * _footerVisibleRateToRefresh - _scrollView.frame.size.height;
-			}else{
-				offset.y = 0;
-			}
+            //fix IOS 11 adjustedContentInset by xusion
+            if (@available(iOS 11.0, *)) {
+                if(_scrollView.contentSize.height + _scrollView.adjustedContentInset.top + _footerView.frame.size.height > _scrollView.frame.size.height){
+                    offset.y = _footerView.frame.origin.y + _footerView.frame.size.height * _footerVisibleRateToRefresh - _scrollView.frame.size.height;
+                }else{
+                    offset.y = 0;
+                }
+            }else{
+                if(_scrollView.contentSize.height + _scrollView.contentInset.top + _footerView.frame.size.height > _scrollView.frame.size.height){
+                    offset.y = _footerView.frame.origin.y + _footerView.frame.size.height * _footerVisibleRateToRefresh - _scrollView.frame.size.height;
+                }else{
+                    offset.y = 0;
+                }
+            }
+			
 		}
 		//log_debug(@"header.h: %.1f, footer.h: %.1f", _headerView.frame.size.height, _footerView.frame.size.height);
 		//log_debug(@"inset.top: %.1f, frame.h: %.1f", _scrollView.contentInset.top, _scrollView.frame.size.height);

--- a/IKit/IPullRefresh.m
+++ b/IKit/IPullRefresh.m
@@ -35,10 +35,10 @@
 	if(_headerView && _headerView.frame.size.height > 0){
 		CGFloat visibleHeight = - (_scrollView.contentInset.top + _scrollView.contentOffset.y);
         
-        //fix IOS 11 adjustedContentInset by xusion
-        if (@available(iOS 11.0, *)) {
-            visibleHeight = - (_scrollView.adjustedContentInset.top + _scrollView.contentOffset.y);
-        }
+		//fix IOS 11 adjustedContentInset by xusion
+		if (@available(iOS 11.0, *)) {
+			visibleHeight = - (_scrollView.adjustedContentInset.top + _scrollView.contentOffset.y);
+		}
         
 		//log_trace(@"header: visibleHeight=%f height=%f", visibleHeight, _headerView.frame.size.height);
 		CGFloat rate = visibleHeight / _headerView.frame.size.height;
@@ -51,20 +51,20 @@
 	if(_footerView && _footerView.frame.size.height > 0){
 		CGFloat visibleHeight;
         
-        //fix IOS 11 adjustedContentInset by xusion
-        if (@available(iOS 11.0, *)) {
-            if(_scrollView.contentSize.height + _scrollView.adjustedContentInset.top > _scrollView.frame.size.height){
-                visibleHeight = _scrollView.contentOffset.y + _scrollView.frame.size.height - _scrollView.contentSize.height;
-            }else{
-                visibleHeight = _scrollView.contentOffset.y + _scrollView.adjustedContentInset.top;
-            }
-        }else{
-            if(_scrollView.contentSize.height + _scrollView.contentInset.top > _scrollView.frame.size.height){
-                visibleHeight = _scrollView.contentOffset.y + _scrollView.frame.size.height - _scrollView.contentSize.height;
-            }else{
-                visibleHeight = _scrollView.contentOffset.y + _scrollView.contentInset.top;
-            }
-        }
+		//fix IOS 11 adjustedContentInset by xusion
+		if (@available(iOS 11.0, *)) {
+			if(_scrollView.contentSize.height + _scrollView.adjustedContentInset.top > _scrollView.frame.size.height){
+				visibleHeight = _scrollView.contentOffset.y + _scrollView.frame.size.height - _scrollView.contentSize.height;
+			}else{
+				visibleHeight = _scrollView.contentOffset.y + _scrollView.adjustedContentInset.top;
+			}
+		}else{
+			if(_scrollView.contentSize.height + _scrollView.contentInset.top > _scrollView.frame.size.height){
+				visibleHeight = _scrollView.contentOffset.y + _scrollView.frame.size.height - _scrollView.contentSize.height;
+			}else{
+				visibleHeight = _scrollView.contentOffset.y + _scrollView.contentInset.top;
+			}
+		}
 		
 		//log_trace(@"footer: visibleHeight=%f height=%f", visibleHeight, _footerView.frame.size.height);
 		//log_trace(@"footer.frame: %@, content: %f, offset: %f", NSStringFromCGRect(_footerView.frame), _scrollView.contentSize.height, _scrollView.contentOffset.y);
@@ -197,20 +197,20 @@
 		}else{
 			tmp_inset.bottom = _footerView.frame.size.height * _footerVisibleRateToRefresh;
 			
-            //fix IOS 11 adjustedContentInset by xusion
-            if (@available(iOS 11.0, *)) {
-                if(_scrollView.contentSize.height + _scrollView.adjustedContentInset.top + _footerView.frame.size.height > _scrollView.frame.size.height){
-                    offset.y = _footerView.frame.origin.y + _footerView.frame.size.height * _footerVisibleRateToRefresh - _scrollView.frame.size.height;
-                }else{
-                    offset.y = 0;
-                }
-            }else{
-                if(_scrollView.contentSize.height + _scrollView.contentInset.top + _footerView.frame.size.height > _scrollView.frame.size.height){
-                    offset.y = _footerView.frame.origin.y + _footerView.frame.size.height * _footerVisibleRateToRefresh - _scrollView.frame.size.height;
-                }else{
-                    offset.y = 0;
-                }
-            }
+			//fix IOS 11 adjustedContentInset by xusion
+			if (@available(iOS 11.0, *)) {
+				if(_scrollView.contentSize.height + _scrollView.adjustedContentInset.top + _footerView.frame.size.height > _scrollView.frame.size.height){
+					offset.y = _footerView.frame.origin.y + _footerView.frame.size.height * _footerVisibleRateToRefresh - _scrollView.frame.size.height;
+				}else{
+					offset.y = 0;
+				}
+			}else{
+				if(_scrollView.contentSize.height + _scrollView.contentInset.top + _footerView.frame.size.height > _scrollView.frame.size.height){
+					offset.y = _footerView.frame.origin.y + _footerView.frame.size.height * _footerVisibleRateToRefresh - _scrollView.frame.size.height;
+				}else{
+					offset.y = 0;
+				}
+			}
 			
 		}
 		//log_debug(@"header.h: %.1f, footer.h: %.1f", _headerView.frame.size.height, _footerView.frame.size.height);

--- a/IKit/ITable.m
+++ b/IKit/ITable.m
@@ -498,6 +498,13 @@
 - (void)constructVisibleCells{
 	CGFloat visibleHeight = _scrollView.frame.size.height - _scrollView.contentInset.top;
 	CGFloat minVisibleY = _scrollView.contentOffset.y + _scrollView.contentInset.top - _contentView.frame.origin.y;
+    
+    //fix IOS 11 adjustedContentInset by xusion
+    if (@available(iOS 11.0, *)) {
+        visibleHeight = _scrollView.frame.size.height - _scrollView.adjustedContentInset.top;
+        minVisibleY = _scrollView.contentOffset.y + _scrollView.adjustedContentInset.top - _contentView.frame.origin.y;
+    }
+    
 	CGFloat maxVisibleY = minVisibleY + visibleHeight;
 	NSUInteger minIndex = NSUIntegerMax;
 	NSUInteger maxIndex = 0;
@@ -604,6 +611,12 @@
 	//log_debug(@"%s", __func__);
 	if(_headerView){
 		CGFloat y = _scrollView.contentOffset.y + _scrollView.contentInset.top;
+        
+        //fix IOS 11 adjustedContentInset by xusion
+        if (@available(iOS 11.0, *)) {
+            y = _scrollView.contentOffset.y + _scrollView.adjustedContentInset.top;
+        }
+        
 		if(y < 0){
 			y = 0;
 		}
@@ -734,6 +747,12 @@
 	//log_trace(@"%s", __func__);
 	if(_headerRefreshControl){
 		CGFloat y = _scrollView.contentOffset.y + _scrollView.contentInset.top;
+        
+        //fix IOS 11 adjustedContentInset by xusion
+        if (@available(iOS 11.0, *)) {
+            y = _scrollView.contentOffset.y + _scrollView.adjustedContentInset.top;
+        }
+        
 		if(y < 0){
 			y = 0;
 		}

--- a/IKit/ITable.m
+++ b/IKit/ITable.m
@@ -499,11 +499,11 @@
 	CGFloat visibleHeight = _scrollView.frame.size.height - _scrollView.contentInset.top;
 	CGFloat minVisibleY = _scrollView.contentOffset.y + _scrollView.contentInset.top - _contentView.frame.origin.y;
     
-    //fix IOS 11 adjustedContentInset by xusion
-    if (@available(iOS 11.0, *)) {
-        visibleHeight = _scrollView.frame.size.height - _scrollView.adjustedContentInset.top;
-        minVisibleY = _scrollView.contentOffset.y + _scrollView.adjustedContentInset.top - _contentView.frame.origin.y;
-    }
+	//fix IOS 11 adjustedContentInset by xusion
+	if (@available(iOS 11.0, *)) {
+		visibleHeight = _scrollView.frame.size.height - _scrollView.adjustedContentInset.top;
+		minVisibleY = _scrollView.contentOffset.y + _scrollView.adjustedContentInset.top - _contentView.frame.origin.y;
+	}
     
 	CGFloat maxVisibleY = minVisibleY + visibleHeight;
 	NSUInteger minIndex = NSUIntegerMax;
@@ -612,10 +612,10 @@
 	if(_headerView){
 		CGFloat y = _scrollView.contentOffset.y + _scrollView.contentInset.top;
         
-        //fix IOS 11 adjustedContentInset by xusion
-        if (@available(iOS 11.0, *)) {
-            y = _scrollView.contentOffset.y + _scrollView.adjustedContentInset.top;
-        }
+		//fix IOS 11 adjustedContentInset by xusion
+		if (@available(iOS 11.0, *)) {
+			y = _scrollView.contentOffset.y + _scrollView.adjustedContentInset.top;
+		}
         
 		if(y < 0){
 			y = 0;
@@ -748,10 +748,10 @@
 	if(_headerRefreshControl){
 		CGFloat y = _scrollView.contentOffset.y + _scrollView.contentInset.top;
         
-        //fix IOS 11 adjustedContentInset by xusion
-        if (@available(iOS 11.0, *)) {
-            y = _scrollView.contentOffset.y + _scrollView.adjustedContentInset.top;
-        }
+		//fix IOS 11 adjustedContentInset by xusion
+		if (@available(iOS 11.0, *)) {
+			y = _scrollView.contentOffset.y + _scrollView.adjustedContentInset.top;
+		}
         
 		if(y < 0){
 			y = 0;


### PR DESCRIPTION
 -修复空格缩进转为tab缩进。  …
-修复IOS11下隐藏了导航条后，scrollview的inset因为save inset引起页面顶部不对齐的问题。如：隐藏导航条，headerview被挡住save inset的高度。